### PR TITLE
Check if size exists in wp_additional_image_sizes

### DIFF
--- a/face-detect.php
+++ b/face-detect.php
@@ -176,7 +176,7 @@ class WP_Detect_Faces {
 				$width  = intval( get_option( $size . '_size_w' ) );
 				$height = intval( get_option( $size . '_size_h' ) );
 				$crop 	= get_option( $size . '_crop' );
-			} else {
+			} else if( isset($_wp_additional_image_sizes[ $size ]) ){
 				$width  = $_wp_additional_image_sizes[ $size ][ 'width' ];
 				$height = $_wp_additional_image_sizes[ $size ][ 'height' ];
 				$crop  	= $_wp_additional_image_sizes[ $size ][ 'crop' ];


### PR DESCRIPTION
I had the problem that the size 'medium_large' was defined in get_intermediate_image_sizes but not in $_wp_additional_image_sizes. 