### PR TITLE
Plugin Compatibility

### DIFF
--- a/includes/class-meauh-admin.php
+++ b/includes/class-meauh-admin.php
@@ -64,7 +64,6 @@ class MEAUH_Admin {
 	 * Includes
 	 */
 	protected function includes() {
-		require_once 'class-meauh-attachment.php';
 	}
 }
 

--- a/my-eyes-are-up-here.php
+++ b/my-eyes-are-up-here.php
@@ -112,6 +112,7 @@ final class MyEyesAreUpHere {
 	 */
 	protected function includes() {
 		require_once 'includes/class-meauh-ajax.php';
+		require_once 'includes/class-meauh-attachment.php';
 
 		if ( $this->is_request( self::REQUEST_ADMIN ) ) {
 			require_once 'includes/class-meauh-admin.php';


### PR DESCRIPTION
Always require attachment class to ensure calculated sizes are available (for better integration with plugins like Fly Dynamic Image Resizer)