### PR TITLE
Action for running custom code after image generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bower_components
 node_modules
 npm-debug.log
+vendor/

--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ Cropped landscape version using this plugin:
 |   --|--   |
 +-----------+
 ```
+
+## Actions
+
+### `meauh_after_image_regeneration`
+#### Parameter
+`$attachment_id` *(int)* Runs just after the image regeneration has finished.

--- a/includes/class-meauh-ajax.php
+++ b/includes/class-meauh-ajax.php
@@ -41,7 +41,7 @@ class MEAUH_Ajax {
 			}
 		}
 
-        add_action( 'wp_ajax_save-attachment-compat', 'save_image', 0, 1 );
+        add_action( 'wp_ajax_save-attachment-compat', [$self, 'save_image'], 0, 1 );
 	}
 
 	/**
@@ -89,7 +89,8 @@ class MEAUH_Ajax {
 		// Regenerate thumbs.
 		$resized = MEAUH_Attachment::regenerate( $attachment_id );
 
-		do_action('meauh_after_image_regeneration', $attachment_id);
+        // Run custom code when finished
+        do_action('meauh_after_image_regeneration', $attachment_id);
 
 		if ( $resized ) {
 			wp_send_json_success( array(

--- a/includes/class-meauh-ajax.php
+++ b/includes/class-meauh-ajax.php
@@ -86,6 +86,9 @@ class MEAUH_Ajax {
 
 		// Regenerate thumbs.
 		$resized = MEAUH_Attachment::regenerate( $attachment_id );
+
+		do_action('meauh_after_image_regeneration', $attachment_id);
+
 		if ( $resized ) {
 			wp_send_json_success( array(
 				'resized' => $resized,

--- a/includes/class-meauh-attachment.php
+++ b/includes/class-meauh-attachment.php
@@ -148,9 +148,20 @@ class MEAUH_Attachment {
 			}
 		}
 
-		$hotspot_src_w = $hotspot_src_max_x - $hotspot_src_x;
-		$hotspot_src_h = $hotspot_src_max_y - $hotspot_src_y;
-
+        // if hot spot max and min are the same its possible that there is only one and the user wants to center it there
+        $hotspot_count = count($hotspots);
+        if($hotspot_count === 1 && $hotspot_src_max_x === $hotspot_src_x) {
+            $hotspot_src_w = $hotspot_src_x / 2;
+        } else {
+            $hotspot_src_w = $hotspot_src_max_x - $hotspot_src_x;
+        }
+        // same goes for height and y axis
+        if($hotspot_count === 1 && $hotspot_src_max_y === $hotspot_src_y) {
+            $hotspot_src_h = $hotspot_src_y / 2;
+        } else {
+            $hotspot_src_h = $hotspot_src_max_y - $hotspot_src_y;
+        }
+        
 		// Crop the largest possible portion of the original image that we can size to $dest_w x $dest_h.
 		$aspect_ratio = $orig_w / $orig_h;
 

--- a/my-eyes-are-up-here.php
+++ b/my-eyes-are-up-here.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class MyEyesAreUpHere {
 	const REQUEST_ADMIN = 'admin';
 	const REQUEST_AJAX = 'ajax';
+    const REQUEST_WP_CLI = 'wp-cli';
 
 	/**
 	 * Instance
@@ -67,6 +68,9 @@ final class MyEyesAreUpHere {
 
 			case self::REQUEST_AJAX:
 				return defined( 'DOING_AJAX' );
+
+            case self::REQUEST_WP_CLI:
+                return ( defined( 'WP_CLI' ) && WP_CLI );
 		}
 	}
 
@@ -116,6 +120,10 @@ final class MyEyesAreUpHere {
 
 		if ( $this->is_request( self::REQUEST_ADMIN ) ) {
 			require_once 'includes/class-meauh-admin.php';
+		}
+
+        if ( $this->is_request( self::REQUEST_WP_CLI ) ) {
+			require_once 'includes/class-meauh-attachment.php';
 		}
 	}
 


### PR DESCRIPTION
We generate additional image formats for all images and need to be able to clean them after an focus point change. Hence we would appreciate to see the following action implemented in core.