### PR TITLE
Guides users to click "finish adding hotspots"

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -46,7 +46,14 @@
 .face-detect-panel .button {
     margin-right: 5px;
     margin-bottom: 5px;
-    display: inline-block;
+    display: block;
+}
+
+.face-detect-panel .button[disabled] ~ .description {
+    display: none;
+}
+.face-detect-panel .button.active ~ .description {
+    display: none;
 }
 
 .status.loading {
@@ -105,4 +112,40 @@
     position: absolute;
     left: 9999px;
     top: -9999px;
+}
+
+.button.add-hotspots.active {
+    background: #3c9e3c;
+    color: #FFF;
+    animation-name: pulse_animation;
+    animation-duration: 3000ms;
+    transform-origin:70% 70%;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+}
+.button.add-hotspots.active:hover {
+    background: #368436;
+}
+
+@keyframes pulse_animation {
+    0% { transform: scale(1); }
+    30% { transform: scale(1); }
+    40% { transform: scale(1.08); }
+    50% { transform: scale(1); }
+    60% { transform: scale(1); }
+    70% { transform: scale(1.05); }
+    80% { transform: scale(1); }
+    100% { transform: scale(1); }
+}
+
+.face-detect-panel__container {
+    display: flex;
+    flex-flow: row wrap;
+}
+.face-detect-panel__container > * {
+    flex: 1 1 200px;
+}
+
+.face-detection-image {
+    margin-bottom: 10px;
 }

--- a/includes/class-meauh-attachment.php
+++ b/includes/class-meauh-attachment.php
@@ -225,8 +225,43 @@ class MEAUH_Attachment {
 		}
 
 		$button .= '
-			</div>
-			<div class="face-detection face-detect-panel">';
+			</div>';
+		
+		$button .= '<div class="face-detect-panel__container">';
+		
+		$button .= '<div class="image-hotspots face-detect-panel">';
+
+		if ( $hotspots ) {
+			$button .= sprintf( '<button class="button add-hotspots has-hotspots" type="button" data-attachment-id="%d">%s</button>',
+				$attachment->ID,
+				__( 'Edit hotspots', 'my-eyes-are-up-here' )
+			);
+		} else {
+			$button .= sprintf( '<button class="button add-hotspots" type="button" data-attachment-id="%d">%s</button>',
+				$attachment->ID,
+				__( 'Add hotspots', 'my-eyes-are-up-here' )
+			);
+		}
+
+		$button .= '<span class="status"></span>';
+		$button .= sprintf( '<p class="description">%s</p>',
+			__( 'Manually add hotspots that you want to avoid cropping.', 'my-eyes-are-up-here' )
+		);
+
+		if ( false && $hotspots ) {
+			$button .= '<p class="added-hotspots">';
+			$button .= sprintf( __( '%d %s found, thumbnails regenerated to fit them into crop area.',
+				'my-eyes-are-up-here' ),
+				count( $hotspots ),
+				_n( 'hotspot', 'hotspots', count( $hotspots ), 'my-eyes-are-up-here' )
+			);
+			$button .= '</p>';
+		}
+
+		$button .= '
+			</div>';
+		
+		$button .= '<div class="face-detection face-detect-panel">';
 
 		if ( $faces ) {
 			$button .= sprintf( '<button class="button face-detection-activate has-faces" type="button" data-attachment-id="%d">%s</button>',
@@ -258,40 +293,14 @@ class MEAUH_Attachment {
 		}
 
 		$button .= '
-			</div>
-			<div class="image-hotspots face-detect-panel">';
+			</div>';
 
-		if ( $hotspots ) {
-			$button .= sprintf( '<button class="button add-hotspots has-hotspots" type="button" data-attachment-id="%d">%s</button>',
-				$attachment->ID,
-				__( 'Edit hotspots', 'my-eyes-are-up-here' )
-			);
-		} else {
-			$button .= sprintf( '<button class="button add-hotspots" type="button" data-attachment-id="%d">%s</button>',
-				$attachment->ID,
-				__( 'Add hotspots', 'my-eyes-are-up-here' )
-			);
-		}
+		$button .= '</div>';
 
-		$button .= '<span class="status"></span>';
-		$button .= sprintf( '<p class="description">%s</p>',
-			__( 'Manually add hotspots that you want to avoid cropping.', 'my-eyes-are-up-here' )
-		);
+		$button .= '<div class="face-detection-crop-preview"></div>
+		<div class="face-detection-image"' . $data_atts . '></div>';
 
-		if ( false && $hotspots ) {
-			$button .= '<p class="added-hotspots">';
-			$button .= sprintf( __( '%d %s found, thumbnails regenerated to fit them into crop area.',
-				'my-eyes-are-up-here' ),
-				count( $hotspots ),
-				_n( 'hotspot', 'hotspots', count( $hotspots ), 'my-eyes-are-up-here' )
-			);
-			$button .= '</p>';
-		}
-
-		$button .= '
-			</div>
-			<div class="face-detection-crop-preview"></div>
-			<div class="face-detection-image"' . $data_atts . '></div>
+		$button .= '	
 		</div>
 		<div class="hide-if-js">
 			<p>' . __( 'This plugin requires javascript to work', 'my-eyes-are-up-here' ) . '</p>


### PR DESCRIPTION
I've been spending a lot of time specifying clients that using this plugin means clicking the dull grey button "finish adding hotspots" and not the bright blue button "update".

This commit tries to improve the user experience so that the users are more clearly guided to click to finish button.

The class-meauh-attachment.php -changes are just moving the div's around and adding a wrapper div to the buttons.

What do you think?
